### PR TITLE
CentOS Link Broken

### DIFF
--- a/source/qig.rst
+++ b/source/qig.rst
@@ -54,7 +54,7 @@ To complete this runbook you'll need the following items:
 #. At least one computer which supports hardware virtualization.
 
 #. The `CentOS 6.4 x86_64 minimal install CD 
-   <http://mirrors.kernel.org/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso>`_
+   <http://mirrors.kernel.org/centos/6/isos/x86_64/>`_
 
 #. A /24 network with the gateway being at xxx.xxx.xxx.1, no DHCP should be on 
    this network and none of the computers running CloudStack will have a 


### PR DESCRIPTION
CentOS ISO link is broken. When new versions come out older versions are archived. Linking to version 6 will pick up the latest 6.x version.