### PR TITLE
corrected -d value while building rpm packages

### DIFF
--- a/source/building_from_source.rst
+++ b/source/building_from_source.rst
@@ -355,7 +355,9 @@ Generating RPMs is done using the ``package.sh`` script:
 
 .. sourcecode:: bash
 
-   $ ./package.sh -d centos6
+   $ ./package.sh -d centos63
+   
+For other supported options(like centos7), run ``./package.sh --help``
 
 That will run for a bit and then place the finished packages in
 ``dist/rpmbuild/RPMS/x86_64/``.


### PR DESCRIPTION
Its listed as centos6 while its centos63.
Also added the help section for other available options