### PR TITLE
Updating installation docs O.S. support: dropping Ubuntu precise support

### DIFF
--- a/source/locale/pot/installation.pot
+++ b/source/locale/pot/installation.pot
@@ -138,7 +138,7 @@ msgstr ""
 
 #: ../../installation.rst:89
 # 29b8ae9600b245fe9c60f040f52adfa5
-msgid "Preferred: CentOS/RHEL 6.3+ or Ubuntu 12.04(.1)"
+msgid "Preferred: CentOS/RHEL 6.3+ or Ubuntu 14.04(.1)"
 msgstr ""
 
 #: ../../installation.rst:91
@@ -259,7 +259,7 @@ msgstr ""
 
 #: ../../installation.rst:170
 # d5c18e89ae43496093da2abe5de613ad
-msgid "You can add a DEB package repository to your apt sources with the following commands. Please note that only packages for Ubuntu 12.04 LTS (precise) are being built at this time."
+msgid "You can add a DEB package repository to your apt sources with the following commands. Please note that only packages for Ubuntu 14.04 LTS (trusty) and Ubuntu 16.04 (Xenial)are being built at this time. DISCLAIMER: Ubuntu 12.04 (Precise) is no longer supported."
 msgstr ""
 
 #: ../../installation.rst:174

--- a/source/management-server/_pkg_repo.rst
+++ b/source/management-server/_pkg_repo.rst
@@ -64,8 +64,8 @@ DEB package repository
 ~~~~~~~~~~~~~~~~~~~~~~
 
 You can add a DEB package repository to your apt sources with the
-following commands. Please note that only packages for Ubuntu 12.04 LTS
-(precise) and Ubuntu 14.04 (trusty) are being built at this time.
+following commands. Please note that only packages for Ubuntu 14.04 LTS
+(Trusty) and Ubuntu 16.04 (Xenial) are being built at this time. DISCLAIMER: Ubuntu 12.04 (Precise) is no longer supported.
 
 Use your preferred editor and open (or create)
 ``/etc/apt/sources.list.d/cloudstack.list``. Add the community provided
@@ -73,7 +73,7 @@ repository to the file:
 
 .. sourcecode:: bash
 
-   deb http://cloudstack.apt-get.eu/ubuntu precise 4.9
+   deb http://cloudstack.apt-get.eu/ubuntu trusty 4.9
 
 We now have to add the public key to the trusted keys.
 


### PR DESCRIPTION
Reasons:
- Ubuntu 12.04 is EOL since April this year
- There is no OpenJDK 8 for it
- Libvirt version is ancient
- Qemu is ancient

http://mail-archives.apache.org/mod_mbox/cloudstack-dev/201709.mbox/%3C1822338225.2390.1506582525752%40ox.pcextreme.nl%3E