### PR TITLE
Updated MySQL documentation for CloudStack management server install

### DIFF
--- a/source/management-server/_database.rst
+++ b/source/management-server/_database.rst
@@ -62,6 +62,18 @@ MySQL. See :ref:`install-database-on-separate-node`.
       max_connections=350
       log-bin=mysql-bin
       binlog-format = 'ROW'
+   ..
+   
+   For Ubuntu 16.04 and later, make sure you specify a ``server-id`` in your ``.cnf`` file for binary logging. Set the          ``server-id`` according to your database setup.
+    
+   .. sourcecode:: bash
+   
+      server-id=master-01
+      innodb_rollback_on_timeout=1
+      innodb_lock_wait_timeout=600
+      max_connections=350
+      log-bin=mysql-bin
+      binlog-format = 'ROW'
 
    .. note:: 
       You can also create a file ``/etc/mysql/conf.d/cloudstack.cnf`` 
@@ -374,4 +386,3 @@ same node for MySQL. See `“Install the Database on the Management Server Node�
 
    You should get the output message “CloudStack Management Server setup is
    done.”
-


### PR DESCRIPTION
Using Ubuntu 16.04 and MySQL 5.7.22, I found specifying a ``server-id`` is critical for running the MySQL process with binary logging. I updated the documentation to include a section about using the ``server-id`` directive for MySQL version 5.7 and later.

If I'm missing anything, please let me know and I'll address.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>